### PR TITLE
boards/ucb: ensure the serial console is enabled in board early init

### DIFF
--- a/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
+++ b/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
@@ -378,7 +378,6 @@
 	ext_osc = <1>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_pcieb>;
-	clkreq-gpio = <&gpio4 1 GPIO_ACTIVE_LOW>;
 	reset-gpio = <&gpio4 0 GPIO_ACTIVE_LOW>;
 	status = "okay";
 };

--- a/board/chargepoint/imx8dxp_ucb/imx8dxp_ucb.c
+++ b/board/chargepoint/imx8dxp_ucb/imx8dxp_ucb.c
@@ -41,6 +41,20 @@
 DECLARE_GLOBAL_DATA_PTR;
 
 
+/*
+ * Rely on the device-tree to setup the peripherals, but setup the
+ * uart0 pads to get the initial prints before the DM code kicks in
+ */
+#define UART_PAD_CTRL	((SC_PAD_CONFIG_OUT_IN << PADRING_CONFIG_SHIFT) | \
+			 (SC_PAD_ISO_OFF << PADRING_LPCONFIG_SHIFT) | \
+			 (SC_PAD_28FDSOI_DSE_DV_HIGH << PADRING_DSE_SHIFT) | \
+			 (SC_PAD_28FDSOI_PS_PU << PADRING_PULL_SHIFT))
+
+static iomux_cfg_t uart0_pads[] = {
+	SC_P_UART0_RX | MUX_PAD_CTRL(UART_PAD_CTRL),
+	SC_P_UART0_TX | MUX_PAD_CTRL(UART_PAD_CTRL),
+};
+
 int board_early_init_f(void)
 {
 	sc_err_t err;
@@ -74,6 +88,8 @@ int board_early_init_f(void)
 		return 0;
 
 	LPCG_AllClockOn(LPUART_0_LPCG);
+
+	imx8_iomux_setup_multiple_pads(uart0_pads, ARRAY_SIZE(uart0_pads));
 
 	return 0;
 }


### PR DESCRIPTION
The DM code will setup the pads correctly for the serial console,
but the initial prints from the boot loader won't show up like
the print_cpuinfo and other banner information. This inits the pads
to get:

    U-Boot 2018.03 (Jun 25 2020 - 06:22:08 +0000)

    CPU:   Freescale i.MX8QXP revC A35 at 1200 MHz at 33C
    Model: ChargePoint i.MX8DXP UCB
    DRAM:  3 GiB

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>