### PR TITLE
boards: update the imx6cpnk and imx8 ucb to handle fitconfig

### DIFF
--- a/board/chargepoint/imx6cpnk/imx6cpnk.c
+++ b/board/chargepoint/imx6cpnk/imx6cpnk.c
@@ -1010,5 +1010,27 @@ int ft_board_setup(void *blob, bd_t *bd)
 		fdt_fixup_ethernet(blob);
 	}
 
+	/*
+	 * Update display reference in the device tree, this just
+	 * sets the native-mode reference.
+	 */
+	do {
+		int r;
+		const char *display;
+
+		display = env_get("display");
+		if (display) {
+			r = fdt_fixup_display(blob,
+					      fdt_get_alias(blob, "lvds0"),
+					      display);
+			if (r >= 0) {
+				fdt_set_status_by_alias(blob, "lvds0",
+							FDT_STATUS_OKAY, 0);
+				debug("Enable lvds0 with %s...\n", display);
+				break;
+			}
+		}
+	} while(0);
+
 	return 0;
 }

--- a/include/configs/imx6cpnk.h
+++ b/include/configs/imx6cpnk.h
@@ -210,12 +210,15 @@
 		"if ext4load mmc ${bootenvpart} " \
 			"${loadaddr} ${bootenv}; then " \
 				"env import -c ${loadaddr} ${filesize} " \
+					"display fitconfig " \
 					"trybootpart bootpart bootlabel; " \
 		"elif ext4load mmc ${bootenvpart} " \
 			"${loadaddr} ${bootenv}-backup; then " \
 				"env import -c ${loadaddr} ${filesize} " \
+					"display fitconfig " \
 					"bootpart bootlabel; " \
 				"env export -c ${loadaddr} " \
+					"display fitconfig " \
 					"trybootpart bootpart bootlabel; " \
 				"ext4write mmc ${bootenvpart} ${loadaddr} " \
 					"/${bootenv} ${filesize}; " \
@@ -228,6 +231,7 @@
 			"setenv -f _trybootpart ${trybootpart}; " \
 			"setenv -f trybootpart; " \
 			"env export -c ${loadaddr} " \
+				"display fitconfig " \
 				"trybootpart bootpart bootlabel; " \
 			"ext4write mmc ${bootenvpart} ${loadaddr} " \
 				"/${bootenv} ${filesize}; " \
@@ -239,11 +243,15 @@
 				"${_trybootpart} ...; " \
 			"ext4load mmc ${_trybootpart} ${loadaddr} " \
 				"${bootfile} && " \
-					"bootm ${loadaddr}; " \
+					"bootm ${bootmarg}; " \
 		"fi; " \
 	"\0" \
 	"mmcboot=setenv -f _bootpart ${bootparta}; " \
 		"run importbootenv; " \
+		"setenv -f bootmarg ${loadaddr}; " \
+		"if test -n $fitconfig; then " \
+			"setenv -f bootmarg ${loadaddr}#${fitconfig}; " \
+		"fi; " \
 		"run mmctryboot; " \
 		"if test -n $bootpart && test $bootpart != none; then " \
 			"setenv -f _bootpart ${bootpart}; " \
@@ -253,7 +261,7 @@
 		"setenv bootargs ${bootargs_secureboot} console=${console} " \
 			"root=PARTUUID=${bootuuid} rootwait rw; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
-			"bootm ${loadaddr}; " \
+			"bootm ${bootmarg}; " \
 		"if test $_bootpart = $bootparta; then " \
 			"setenv -f _bootpart ${bootpartb}; " \
 		"else " \
@@ -264,7 +272,7 @@
 		"setenv bootargs ${bootargs_secureboot} console=${console} " \
 			"root=PARTUUID=${bootuuid} rootwait rw; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
-			"bootm ${loadaddr}; " \
+			"bootm ${bootmarg}; " \
 	"\0"
 
 #define CONFIG_BOOTCOMMAND \

--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -161,15 +161,15 @@
 		"if ext4load mmc ${bootenvpart} " \
 			"${loadaddr} ${bootenv}; then " \
 				"env import -c ${loadaddr} ${filesize} " \
-					"lvds0-display lvds1-display " \
+					"display fitconfig " \
 					"trybootpart bootpart bootlabel; " \
 		"elif ext4load mmc ${bootenvpart} " \
 			"${loadaddr} ${bootenv}-backup; then " \
 				"env import -c ${loadaddr} ${filesize} " \
-					"lvds0-display lvds1-display " \
+					"display fitconfig " \
 					"bootpart bootlabel; " \
 				"env export -c ${loadaddr} " \
-					"lvds0-display lvds1-display " \
+					"display fitconfig " \
 					"trybootpart bootpart bootlabel; " \
 				"ext4write mmc ${bootenvpart} ${loadaddr} " \
 					"/${bootenv} ${filesize}; " \
@@ -182,7 +182,7 @@
 			"setenv -f _trybootpart ${trybootpart}; " \
 			"setenv -f trybootpart; " \
 			"env export -c ${loadaddr} " \
-				"lvds0-display lvds1-display " \
+				"display fitconfig " \
 				"trybootpart bootpart bootlabel; " \
 			"ext4write mmc ${bootenvpart} ${loadaddr} " \
 				"/${bootenv} ${filesize}; " \
@@ -194,12 +194,15 @@
 				"${_trybootpart} ...; " \
 			"ext4load mmc ${_trybootpart} ${loadaddr} " \
 				"${bootfile} && " \
-					"bootm ${loadaddr}; " \
+					"bootm ${bootmarg}; " \
 		"fi; " \
 	"\0" \
 	"mmcboot=setenv -f _bootpart ${bootparta}; " \
 		"run importbootenv; " \
-		"gpio set 133; " \
+		"setenv -f bootmarg ${loadaddr}; " \
+		"if test -n $fitconfig; then " \
+			"setenv -f bootmarg ${loadaddr}#${fitconfig}; " \
+		"fi; " \
 		"run mmctryboot; " \
 		"if test -n $bootpart && test $bootpart != none; then " \
 			"setenv -f _bootpart ${bootpart}; " \
@@ -209,7 +212,7 @@
 		"setenv bootargs ${bootargs_secureboot} console=${console} " \
 			"root=PARTUUID=${bootuuid} rootwait rw; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
-			"bootm ${loadaddr}; " \
+			"bootm ${bootmarg}; " \
 		"if test $_bootpart = $bootparta; then " \
 			"setenv -f _bootpart ${bootpartb}; " \
 		"else " \
@@ -220,7 +223,7 @@
 		"setenv bootargs ${bootargs_secureboot} console=${console} " \
 			"root=PARTUUID=${bootuuid} rootwait rw; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
-			"bootm ${loadaddr}; " \
+			"bootm ${bootmarg}; " \
 	"\0"
 
 


### PR DESCRIPTION
A goal of this build is to handle multiple device tree configurations
in case they need to overridden for an enclosure. Specifically,
the UCB has multiple display options and thus the interfaces and
setups should be handled appropriately between different devicetree

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>