### PR TITLE
boards/chargepoint: add brackets around the variable expansion for test

### DIFF
--- a/include/configs/imx6cpnk.h
+++ b/include/configs/imx6cpnk.h
@@ -225,7 +225,7 @@
 		"fi; " \
 	"\0" \
 	"mmctryboot=" \
-		"if test -n $trybootpart; then " \
+		"if test -n ${trybootpart}; then " \
 			"echo Try-boot ${bootfile} from " \
 				"mmc ${trybootpart} ...; " \
 			"setenv -f _trybootpart ${trybootpart}; " \
@@ -249,11 +249,11 @@
 	"mmcboot=setenv -f _bootpart ${bootparta}; " \
 		"run importbootenv; " \
 		"setenv -f bootmarg ${loadaddr}; " \
-		"if test -n $fitconfig; then " \
+		"if test -n ${fitconfig}; then " \
 			"setenv -f bootmarg ${loadaddr}#${fitconfig}; " \
 		"fi; " \
 		"run mmctryboot; " \
-		"if test -n $bootpart && test $bootpart != none; then " \
+		"if test -n ${bootpart} && test ${bootpart} != none; then " \
 			"setenv -f _bootpart ${bootpart}; " \
 		"fi; " \
 		"echo Booting ${bootfile} from mmc ${_bootpart} ...; " \
@@ -262,7 +262,7 @@
 			"root=PARTUUID=${bootuuid} rootwait rw; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${bootmarg}; " \
-		"if test $_bootpart = $bootparta; then " \
+		"if test ${_bootpart} = ${bootparta}; then " \
 			"setenv -f _bootpart ${bootpartb}; " \
 		"else " \
 			"setenv -f _bootpart ${bootparta}; " \

--- a/include/configs/imx6pbc.h
+++ b/include/configs/imx6pbc.h
@@ -216,7 +216,7 @@
 		"fi; " \
 	"\0" \
 	"mmctryboot=" \
-		"if test -n $trybootpart; then " \
+		"if test -n ${trybootpart}; then " \
 			"echo Try-boot ${bootfile} from " \
 				"mmc ${trybootpart} ...; " \
 			"setenv -f _trybootpart ${trybootpart}; " \
@@ -239,7 +239,7 @@
 	"mmcboot=setenv -f _bootpart ${bootparta}; " \
 		"run importbootenv; " \
 		"run mmctryboot; " \
-		"if test -n $bootpart && test $bootpart != none; then " \
+		"if test -n ${bootpart} && test ${bootpart} != none; then " \
 			"setenv -f _bootpart ${bootpart}; " \
 		"fi; " \
 		"echo Booting ${bootfile} from mmc ${_bootpart} ...; " \
@@ -248,7 +248,7 @@
 			"root=PARTUUID=${bootuuid} rootwait rw; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${loadaddr}; " \
-		"if test $_bootpart = $bootparta; then " \
+		"if test ${_bootpart} = ${bootparta}; then " \
 			"setenv -f _bootpart ${bootpartb}; " \
 		"else " \
 			"setenv -f _bootpart ${bootparta}; " \

--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -176,7 +176,7 @@
 		"fi; " \
 	"\0" \
 	"mmctryboot=" \
-		"if test -n $trybootpart; then " \
+		"if test -n ${trybootpart}; then " \
 			"echo Try-boot ${bootfile} from " \
 				"mmc ${trybootpart} ...; " \
 			"setenv -f _trybootpart ${trybootpart}; " \
@@ -200,11 +200,11 @@
 	"mmcboot=setenv -f _bootpart ${bootparta}; " \
 		"run importbootenv; " \
 		"setenv -f bootmarg ${loadaddr}; " \
-		"if test -n $fitconfig; then " \
+		"if test -n ${fitconfig}; then " \
 			"setenv -f bootmarg ${loadaddr}#${fitconfig}; " \
 		"fi; " \
 		"run mmctryboot; " \
-		"if test -n $bootpart && test $bootpart != none; then " \
+		"if test -n ${bootpart} && test ${bootpart} != none; then " \
 			"setenv -f _bootpart ${bootpart}; " \
 		"fi; " \
 		"echo Booting ${bootfile} from mmc ${_bootpart} ...; " \
@@ -213,7 +213,7 @@
 			"root=PARTUUID=${bootuuid} rootwait rw; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${bootmarg}; " \
-		"if test $_bootpart = $bootparta; then " \
+		"if test ${_bootpart} = ${bootparta}; then " \
 			"setenv -f _bootpart ${bootpartb}; " \
 		"else " \
 			"setenv -f _bootpart ${bootparta}; " \


### PR DESCRIPTION
There was an evaluation of the comparison on the bootparts that wasn't
generating a true as expected. It seems to be tied to the variable
expansion of with brackets and would result in the same bootpart being
tried in the fallback case that was done as the start.

    Booting fitImage from mmc 0:2 ...
    ** File not found fitImage **
    Failover boot fitImage from mmc 0:2 ...
    ** File not found fitImage **

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>