### PR TITLE
rsa: Return immediately if required-key verification fails

### DIFF
--- a/lib/rsa/rsa-verify.c
+++ b/lib/rsa/rsa-verify.c
@@ -230,8 +230,7 @@ int rsa_verify(struct image_sign_info *info,
 	if (info->required_keynode != -1) {
 		ret = rsa_verify_with_keynode(info, hash, sig, sig_len,
 			info->required_keynode);
-		if (!ret)
-			return ret;
+		return ret;
 	}
 
 	/* Look for a key that matches our hint */


### PR DESCRIPTION
Currently, if image verification with a required key fails, rsa_verify()
code tries to find another key to verify the FIT image. This however, is
not the intended behavior as the documentation says that required keys
"must be verified for the image / configuration to be considered valid".

This patch fixes the issue by making rsa_verify() return immediately if
the verification of a required key fails.

Signed-off-by: Daniele Alessandrelli <daniele.alessandrelli@gmail.com>
(cherry picked from commit 0772a1f4973031d6a30482cf7610f691b6bc1e6d)