### PR TITLE
board/chargepoint: fix key-name-hint format

### DIFF
--- a/board/chargepoint/imx6cpnk/prod-pubkey-cpnk.dtsi
+++ b/board/chargepoint/imx6cpnk/prod-pubkey-cpnk.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	signature {
-		key-fit-cpnk {
+		key-fit-prod-cpnk {
 			/* TODO: Generate Production Key.
 			 *     This is a throwaway key for verification of the secure boot
 			 *     logic prior to generating production keys.
@@ -21,7 +21,7 @@
 			rsa,exponent = < 0x00 0x10001 >;
 			rsa,n0-inverse = < 0x13a24343 >;
 			rsa,num-bits = < 0x1000 >;
-			key-name-hint = "fit-cpnk";
+			key-name-hint = "fit-prod-cpnk";
 		};
 	};
 };

--- a/board/chargepoint/imx6pbc/prod-pubkey-pbc.dtsi
+++ b/board/chargepoint/imx6pbc/prod-pubkey-pbc.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	signature {
-		key-fit-cpnk {
+		key-fit-prod-pbc {
 			/* TODO: Generate Production Key.
 			 *     This is a throwaway key for verification of the secure boot
 			 *     logic prior to generating production keys.
@@ -21,7 +21,7 @@
 			rsa,exponent = < 0x00 0x10001 >;
 			rsa,n0-inverse = < 0x13a24343 >;
 			rsa,num-bits = < 0x1000 >;
-			key-name-hint = "fit-cpnk";
+			key-name-hint = "fit-prod-pbc";
 		};
 	};
 };

--- a/board/chargepoint/imx8dxp_ucb/prod-pubkey-ucb.dtsi
+++ b/board/chargepoint/imx8dxp_ucb/prod-pubkey-ucb.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	signature {
-		key-fit-ucb {
+		key-fit-prod-ucb {
 			/* TODO: Generate Production Key.
 			 *     This is a throwaway key for verification of the secure boot
 			 *     logic prior to generating production keys.
@@ -21,7 +21,7 @@
 			rsa,exponent = < 0x00 0x10001 >;
 			rsa,n0-inverse = < 0x13a24343 >;
 			rsa,num-bits = < 0x1000 >;
-			key-name-hint = "fit-ucb";
+			key-name-hint = "fit-prod-ucb";
 		};
 	};
 };


### PR DESCRIPTION
The key name hint should use the format

fit-<env>-<board>

<env> - "qa" or "prod"
<board> - "ucb", "pbc", or "cpnk"