### PR TITLE
boards: for the pbc, ucb, and cpnk board use a hard reboot mode

### DIFF
--- a/include/configs/imx6cpnk.h
+++ b/include/configs/imx6cpnk.h
@@ -189,7 +189,7 @@
  */
 #define CONFIG_MFG_ENV_SETTINGS \
 	"mfgtool_args=setenv bootargs console=${console},${baudrate} " \
-		"earlyprintk=serial ignore_loglevel debug " \
+		"reboot=h earlyprintk=serial ignore_loglevel debug " \
 		"clk_ignore_unused root=/dev/ram " \
 		"\0" \
 	"bootcmd_mfg=run mfgtool_args; " \

--- a/include/configs/imx6pbc.h
+++ b/include/configs/imx6pbc.h
@@ -183,7 +183,7 @@
  */
 #define CONFIG_MFG_ENV_SETTINGS \
 	"mfgtool_args=setenv bootargs console=${console},${baudrate} " \
-		"earlyprintk=serial ignore_loglevel debug " \
+		"reboot=h earlyprintk=serial ignore_loglevel debug " \
 		"clk_ignore_unused root=/dev/ram " \
 		"\0" \
 	"bootcmd_mfg=run mfgtool_args; " \

--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -141,7 +141,7 @@
 
 #define CONFIG_MFG_ENV_SETTINGS \
 	"mfgtool_args=setenv bootargs console=${console},${baudrate} " \
-		"earlyprintk=serial ignore_loglevel debug " \
+		"reboot=h earlyprintk=serial ignore_loglevel debug " \
 		"clk_ignore_unused root=/dev/ram " \
 		"\0" \
 	"bootcmd_mfg=run mfgtool_args; " \


### PR DESCRIPTION
For the mfgtools - define a hard reboot mode that should be used
for the boards from linux. The default in linux is compiled in
to kernel/reboot.c but this should enforce a hard reset for all
the fastboot setups.

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>