### PR TITLE
boards: with the linux updates the aliases on the ethernet is "ethern…

### DIFF
--- a/include/configs/imx6cpnk.h
+++ b/include/configs/imx6cpnk.h
@@ -51,6 +51,7 @@
 /* Environment organization */
 #define CONFIG_ENV_SIZE			(8 * SZ_1K)
 #define CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
+#define FDT_SEQ_MACADDR_FROM_ENV
 
 /* Serial */
 #define CONFIG_MXC_UART

--- a/include/configs/imx6pbc.h
+++ b/include/configs/imx6pbc.h
@@ -50,6 +50,7 @@
 /* Environment organization */
 #define CONFIG_ENV_SIZE			(8 * SZ_1K)
 #define CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
+#define FDT_SEQ_MACADDR_FROM_ENV
 
 /* Serial */
 #define CONFIG_MXC_UART

--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -58,6 +58,7 @@
 #define CONFIG_ENV_SIZE                 (8 * SZ_1K)
 #define CONFIG_ENV_OVERWRITE
 #define CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
+#define FDT_SEQ_MACADDR_FROM_ENV
 
 /* Default environment is in mmcblk0boot1 */
 #define CONFIG_SYS_MMC_ENV_DEV          0   /* mmcblk0 */


### PR DESCRIPTION
…et0"

In the devicetree on the later kernels, the alias for the ethernet is
changed to ethernet0 and so need to enable the support for that indexing
in the fdt_fixup_ethernet code path with by adding the definition
FDT_SEQ_MACADDR_FROM_ENV into the configs.

Specifically this code in change

                path = fdt_getprop_by_offset(fdt, offset, &name, NULL);
                if (!strncmp(name, "ethernet", 8)) {
                        /* Treat plain "ethernet" same as "ethernet0". */
                        if (!strcmp(name, "ethernet")
    #ifdef FDT_SEQ_MACADDR_FROM_ENV
                         || !strcmp(name, "ethernet0")
    #endif

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>