### PR TITLE
boards: fix a typo in the include configs for imx8dxp_ucb

### DIFF
--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -138,7 +138,7 @@
  * Resource checking produces unwanted device tree warnings.
  * Happened after UCB switched to 5.4 kernel dt bindings.
  */
-#define CONFIG_SKIP_RESOURCE_CHECING
+#define CONFIG_SKIP_RESOURCE_CHECKING
 
 #define CONFIG_MFG_ENV_SETTINGS \
 	"mfgtool_args=setenv bootargs console=${console},${baudrate} " \


### PR DESCRIPTION
A configuration variable was incorrectly labeled, caught in porting
efforts to later u-boot versions

    Error: You must add new CONFIG options using Kconfig
    The following new ad-hoc CONFIG options were detected:
    CONFIG_SKIP_RESOURCE_CHECING

Address the typo and eliminate the warning

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>