### PR TITLE
boards: keep the switch in reset on the bootloader startup

### DIFF
--- a/board/chargepoint/imx6pbc/imx6pbc.c
+++ b/board/chargepoint/imx6pbc/imx6pbc.c
@@ -160,6 +160,7 @@ static struct gpio_ni gpios_output_low[] = {
 	NI(FAN1_SP_CTRL),
 	NI(FAN2_SP_CTRL),
 	NI(RTD_START_SYNC),
+	NI(PHY_RSTn),
 	NI(RS485_DE),
 	NI(RS485_REn),
 
@@ -170,7 +171,6 @@ static struct gpio_ni gpios_output_high[] = {
 #define NI(_x)	{ .name = #_x,  .id = _x }
 
 	NI(ETH_PWR_EN),
-	NI(PHY_RSTn),
 	NI(SER_PWR_EN),
 	NI(EN_PMIC_I2C),
 	NI(PM_RESET_N),


### PR DESCRIPTION
The marvell switch needs to stay in reset when the power stabilizes,
so keep the reset low (active low) while the system boots since the
linux driver will need to reset it anyway and this just keeps
things saner during the bootloader.

[PLAT-2437]

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>

[PLAT-2437]: https://chargepoint.atlassian.net/browse/PLAT-2437