### PR TITLE
MLK-23813 imx8: fuse: Skip ECC fuses check according to env variable

### DIFF
--- a/arch/arm/mach-imx/imx8/fuse.c
+++ b/arch/arm/mach-imx/imx8/fuse.c
@@ -70,6 +70,7 @@ int fuse_sense(u32 bank, u32 word, u32 *val)
 
 int fuse_prog(u32 bank, u32 word, u32 val)
 {
+	int force_prog = 0;
 	if (bank != 0) {
 		printf("Invalid bank argument, ONLY bank 0 is supported\n");
 		return -EINVAL;
@@ -81,19 +82,21 @@ int fuse_prog(u32 bank, u32 word, u32 val)
 	}
 #endif
 
-    if (((word >= FSL_ECC_WORD_START_1) && (word <= FSL_ECC_WORD_END_1)) ||
-		((word >= FSL_ECC_WORD_START_2) && (word <= FSL_ECC_WORD_END_2)))
-       {
-             puts("Warning: Words in this index range have ECC protection and\n"
-                  "can only be programmed once per word. Individual bit operations will\n"
-                  "be rejected after the first one. \n"
-                  "\n\n Really program this word? <y/N> \n");
+	force_prog = env_get_yesno("force_prog_ecc");
+	if (force_prog != 1) {
+		if (((word >= FSL_ECC_WORD_START_1) && (word <= FSL_ECC_WORD_END_1)) ||
+		    ((word >= FSL_ECC_WORD_START_2) && (word <= FSL_ECC_WORD_END_2))) {
+			puts("Warning: Words in this index range have ECC protection and\n"
+			     "can only be programmed once per word. Individual bit operations will\n"
+			     "be rejected after the first one.\n"
+			     "\n\n Really program this word? <y/N>\n");
 
-             if(!confirm_yesno()) {
-                 puts("Word programming aborted\n");
-                 return -EPERM;
-             }
-       }
+			if (!confirm_yesno()) {
+				puts("Word programming aborted\n");
+				return -EPERM;
+			}
+		}
+	}
 
 #if defined(CONFIG_SMC_FUSE)
 	return call_imx_sip(FSL_SIP_OTP_WRITE, (unsigned long)word,\


### PR DESCRIPTION
Currently it's not possible to use UUU to program ECC words. U-Boot is
asking for a second confirmation when programming ECC covered words.
Introduce a environment variable "force_prog_ecc", if the env is set
to "y" or "1", then the ecc fuse checking is skipped.

In uuu usage, just set this variable in uuu script, then there is no
second confirmation needed.

Signed-off-by: Ye Li <ye.li@nxp.com>
Reviewed-by: Peng Fan <peng.fan@nxp.com>
(cherry picked from commit 67fb736f49bcbf42576254b627cee2a8be4d58ed)