### PR TITLE
board/mcb: recovery from serial number changes masking errors

### DIFF
--- a/board/chargepoint/imx8mm_mcb/imx8mm_mcb.c
+++ b/board/chargepoint/imx8mm_mcb/imx8mm_mcb.c
@@ -98,5 +98,7 @@ int ft_board_setup(void *blob, bd_t *bd)
 
 		fdt_root(blob);
 	}
+
+	return 0;
 }
 #endif

--- a/include/configs/chargepoint_imx8mm_mcb.h
+++ b/include/configs/chargepoint_imx8mm_mcb.h
@@ -68,7 +68,6 @@
 	"bootfile=fitImage\0" \
 	"bootparta=2:2\0" \
 	"bootpartb=2:3\0" \
-    "loadaddr=0x71000000\0" \
 	"importbootenv=echo Importing env from mmc ${bootenvpart} ...; " \
 		"part uuid mmc ${bootenvpart} bootenvuuid; " \
 		"if ext4load mmc ${bootenvpart} " \
@@ -149,8 +148,16 @@
 #define CONFIG_BOOTARGS \
 	"console=" CONSOLE_DEV ",115200 earlyprintk=serial ignore_loglevel"
 
-/* Link Definitions */
-#define CONFIG_LOADADDR			0x40000000
+/*
+ * Link Definitions
+ *
+ * NOTE: loadaddr tracks the fastboot buffer for a fit image boot, the
+ *       size and location of a buffer allows the relocation and extraction
+ *       of the kernel to lower memory and the initrd to relocate to upper
+ *       memory. This is a deviation from the imx8mm references that don't
+ *       use FIT images.
+ */
+#define CONFIG_LOADADDR			0x71000000
 
 #define CONFIG_SYS_LOAD_ADDR		CONFIG_LOADADDR
 


### PR DESCRIPTION
There was a missing return in a function and uboot doesn't do
Werror so that fell thru. Found an incorrect loadaddr in the
configuration and mfg environment.

The FASTBOOT changes are not required because the uuu will set
the address and can set the size as needed, but this matches
the imx8mm 1g android configuration numbers in the tree so just
making it a nice to have.

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>