### PR TITLE
boards/chargepoint: read SRC Reset Status Register only once

### DIFF
--- a/board/chargepoint/common/bootreason.h
+++ b/board/chargepoint/common/bootreason.h
@@ -64,12 +64,15 @@ static inline const char *get_wdog_reset_reason(void)
 static inline const char *get_wdog_reset_reason(void)
 {
 	u32 cause;
+#if defined(CONFIG_DISPLAY_CPUINFO) && !defined(CONFIG_SPL_BUILD)
+	cause = get_imx_reset_cause();
+#else
 	struct src *src_regs = (struct src *)SRC_BASE_ADDR;
 
 	/* Reset register is not always cleared, so read and reset */
 	cause = readl(&src_regs->srsr);
 	writel(cause, &src_regs->srsr);
-
+#endif
 	switch (cause) {
 	case 0x00001:
 	case 0x00011:


### PR DESCRIPTION
Use saved SRC Reset Status if it was read by get_reset_cause()
earlier. Read the register only if it wasn't read and erased
before.

[PLAT-4614]

Signed-off-by: Dmytro Bagrii <dmytro.bagrii-ext@chargepoint.com>

[PLAT-4614]: https://chargepoint.atlassian.net/browse/PLAT-4614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ