### PR TITLE
board/chargepoint: pass the hard reset option for the reboot

### DIFF
--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -189,7 +189,7 @@
 			"ext4write mmc ${bootenvpart} ${loadaddr} " \
 				"/${bootenv} ${filesize}; " \
 			"part uuid mmc ${_trybootpart} bootuuid; " \
-			"setenv bootargs ${bootargs_secureboot} " \
+			"setenv bootargs reboot=h ${bootargs_secureboot} " \
 				"console=${console} " \
 				"bootenv=PARTUUID=${bootenvuuid} " \
 				"root=PARTUUID=${bootuuid} rootwait rw " \
@@ -213,7 +213,8 @@
 		"fi; " \
 		"echo Booting ${bootfile} from mmc ${_bootpart} ...; " \
 		"part uuid mmc ${_bootpart} bootuuid; " \
-		"setenv bootargs ${bootargs_secureboot} console=${console} " \
+		"setenv bootargs reboot=h ${bootargs_secureboot} " \
+			"console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
 			"root=PARTUUID=${bootuuid} rootwait rw " \
 			"${bootargs_append}; " \
@@ -226,7 +227,8 @@
 		"fi; " \
 		"echo Failover boot ${bootfile} from mmc ${_bootpart} ...; " \
 		"part uuid mmc ${_bootpart} bootuuid; " \
-		"setenv bootargs ${bootargs_secureboot} console=${console} " \
+		"setenv bootargs reboot=h ${bootargs_secureboot} " \
+			"console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
 			"root=PARTUUID=${bootuuid} rootwait rw " \
 			"${bootargs_append}; " \


### PR DESCRIPTION
The kernel is patched to make the hard reboot trigger a PMIC
watchdog reset external to the m4. The default in the NXP kernel
is to soft reset with the m4 chip internally and record the
reset reasons - etc. in the registers. This will change on a
reboot command but CPU watchdogs should still go thru the m4.

At this time this was requested to see if the eMMC/usdhc interface
will get reset and might mask the problem for the undiscoverable
MMC device in the bootloader. Technically, this should not be
needed - but, an unknown bug might be handled with this workaround

Fixes: [PLAT-5902]

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>

[PLAT-5902]: https://chargepoint.atlassian.net/browse/PLAT-5902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ