### PR TITLE
board/ucb: remove unneeded if defined guard around the bootargs

### DIFF
--- a/board/chargepoint/imx8dxp_ucb/imx8dxp_ucb.c
+++ b/board/chargepoint/imx8dxp_ucb/imx8dxp_ucb.c
@@ -329,10 +329,8 @@ int board_late_init(void)
 			break;
 
 		case 0x80: /* OEM closed */
-#if defined(CONIG_NOT_UUU_BUILD)
 			/* set an environment that this is a secure boot */
 			env_set("bootargs_secureboot", "uboot-secureboot");
-#endif
 			break;
 		}
 	}


### PR DESCRIPTION
There was a macro guard around setting the secureboot environment
when the HAB was determined closed. At the time, it was thought that
this made sense because a provision image would send the flag up
but after examination that isn't a problem or a bad thing. The
diagnostics on a secured unit should run in either mode to make
things simpler.

Fixes: [PLAT-6074]

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>

[PLAT-6074]: https://chargepoint.atlassian.net/browse/PLAT-6074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ