### PR TITLE
boards: add a systemd.unit for the rescue target on failover boots

### DIFF
--- a/include/configs/chargepoint_imx8dxl_kcb.h
+++ b/include/configs/chargepoint_imx8dxl_kcb.h
@@ -256,7 +256,8 @@
 			"setenv bootargs ${bootargs_secureboot} " \
 				"console=${console} " \
 				"bootenv=PARTUUID=${bootenvuuid} " \
-				"root=PARTUUID=${bootuuid} rootwait rw; " \
+				"root=PARTUUID=${bootuuid} rootwait rw " \
+				"${bootargs_append}; " \
 			"echo Try-booting ${bootfile} from mmc " \
 				"${_trybootpart} ...; " \
 			"ext4load mmc ${_trybootpart} ${loadaddr} " \
@@ -278,7 +279,8 @@
 		"part uuid mmc ${_bootpart} bootuuid; " \
 		"setenv bootargs ${bootargs_secureboot} console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
-			"root=PARTUUID=${bootuuid} rootwait rw; " \
+			"root=PARTUUID=${bootuuid} rootwait rw " \
+			"${bootargs_append}; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${bootmarg}; " \
 		"if test ${_bootpart} = ${bootparta}; then " \
@@ -290,7 +292,9 @@
 		"part uuid mmc ${_bootpart} bootuuid; " \
 		"setenv bootargs ${bootargs_secureboot} console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
-			"root=PARTUUID=${bootuuid} rootwait rw; " \
+			"root=PARTUUID=${bootuuid} rootwait rw " \
+			"systemd.unit=rescue.target " \
+			"${bootargs_append}; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${bootmarg}; " \
 	"\0"

--- a/include/configs/chargepoint_imx8mm_mcb.h
+++ b/include/configs/chargepoint_imx8mm_mcb.h
@@ -102,7 +102,8 @@
 			"setenv bootargs ${bootargs_secureboot} " \
 				"console=${console},${baudrate} " \
 				"bootenv=PARTUUID=${bootenvuuid} " \
-				"root=PARTUUID=${bootuuid} rootwait rw; " \
+				"root=PARTUUID=${bootuuid} rootwait rw " \
+				"${bootargs_append}; " \
 			"echo Try-booting ${bootfile} from mmc " \
 				"${_trybootpart} ...; " \
 			"ext4load mmc ${_trybootpart} ${loadaddr} " \
@@ -122,9 +123,10 @@
 		"fi; " \
 		"echo Booting ${bootfile} from mmc ${_bootpart} ...; " \
 		"part uuid mmc ${_bootpart} bootuuid; " \
-		"setenv bootargs ${bootargs_secureboot} console=${console},${baudrate} " \
+		"setenv bootargs ${bootargs_secureboot} console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
-			"root=PARTUUID=${bootuuid} rootwait rw; " \
+			"root=PARTUUID=${bootuuid} rootwait rw " \
+			"${bootargs_append}; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${bootmarg}; " \
 		"if test ${_bootpart} = ${bootparta}; then " \
@@ -134,9 +136,11 @@
 		"fi; " \
 		"echo Failover boot ${bootfile} from mmc ${_bootpart} ...; " \
 		"part uuid mmc ${_bootpart} bootuuid; " \
-		"setenv bootargs ${bootargs_secureboot} console=${console},${baudrate} " \
+		"setenv bootargs ${bootargs_secureboot} console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
-			"root=PARTUUID=${bootuuid} rootwait rw; " \
+			"root=PARTUUID=${bootuuid} rootwait rw " \
+			"systemd.unit=rescue.target " \
+			"${bootargs_append}; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${bootmarg}; " \
 	"\0"


### PR DESCRIPTION
When the primary partition does not boot, add the rescue target into the bootargs to force systemd to run a rescue mode. This can be tested by delete the kernel of the committed partition and triggering the failover boot mode.

As watchdogs and other commits are added the failover case will be triggered under multiple conditions but the outcome from the boot will fall into the rescue target being run.

Fixes: [PLAT-6388]

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>

[PLAT-6388]: https://chargepoint.atlassian.net/browse/PLAT-6388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ