### PR TITLE
boards: add a systemd.unit for the rescue target on failover boots

### DIFF
--- a/include/configs/imx6cpnk.h
+++ b/include/configs/imx6cpnk.h
@@ -298,6 +298,7 @@
 			"console=${console} video=${video} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
 			"root=PARTUUID=${bootuuid} rootwait rw " \
+			"systemd.unit=rescue.target " \
 			"${bootargs_append}; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${bootmarg}; " \

--- a/include/configs/imx6pbc.h
+++ b/include/configs/imx6pbc.h
@@ -264,6 +264,7 @@
 		"setenv bootargs ${bootargs_secureboot} console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
 			"root=PARTUUID=${bootuuid} rootwait rw " \
+			"systemd.unit=rescue.target " \
 			"${bootargs_append}; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${loadaddr}; " \

--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -231,6 +231,7 @@
 			"console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
 			"root=PARTUUID=${bootuuid} rootwait rw " \
+			"systemd.unit=rescue.target " \
 			"${bootargs_append}; " \
 		"ext4load mmc ${_bootpart} ${loadaddr} ${bootfile} && " \
 			"bootm ${bootmarg}; " \


### PR DESCRIPTION
When the primary partition does not boot, add the rescue target into the bootargs to force systemd to run a rescue mode. This can be tested by delete the kernel of the committed partition and triggering the failover boot mode.

As watchdogs and other commits are added the failover case will be triggered under multiple conditions but the outcome from the boot will fall into the rescue target being run.

Fixes: [PLAT-6388]

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>

[PLAT-6388]: https://chargepoint.atlassian.net/browse/PLAT-6388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ