### PR TITLE
fdt: Add U-Boot version to chosen node

### DIFF
--- a/common/fdt_support.c
+++ b/common/fdt_support.c
@@ -17,6 +17,7 @@
 #include <fdt_support.h>
 #include <exports.h>
 #include <fdtdec.h>
+#include <version.h>
 
 /**
  * fdt_getprop_u32_default_node - Return a node's property or a default
@@ -298,6 +299,15 @@ int fdt_chosen(void *fdt)
 			       fdt_strerror(err));
 			return err;
 		}
+	}
+
+	/* add u-boot version */
+	err = fdt_setprop(fdt, nodeoffset, "u-boot,version", PLAIN_VERSION,
+			  strlen(PLAIN_VERSION) + 1);
+	if (err < 0) {
+		printf("WARNING: could not set u-boot,version %s.\n",
+		       fdt_strerror(err));
+		return err;
 	}
 
 	return fdt_fixup_stdout(fdt, nodeoffset);


### PR DESCRIPTION
Add a new device tree property "u-boot,version" in the chosen node to pass the U-Boot version to the operating system.
This can be useful to implement a firmware upgrade procedure from the operating system.

Signed-off-by: Francesco Dolcini <francesco.dolcini@toradex.com>
Reviewed-by: Tom Rini <trini@konsulko.com>
(cherry picked from commit 622ecee93a604c017aca23906c5cc903b4002b78)