### PR TITLE
board/ucb: energystar updates

### DIFF
--- a/board/chargepoint/imx8dxp_ucb/imx8dxp_ucb.c
+++ b/board/chargepoint/imx8dxp_ucb/imx8dxp_ucb.c
@@ -613,6 +613,15 @@ static void enable_wifi_regulator(void *blob)
 	}
 }
 
+#define KERNEL_HEARTBEAT_LED_PATH "/leds/DBG_LED_5"
+static void disable_kernel_heartbeat(void *blob)
+{
+	int offs = fdt_path_offset(blob, KERNEL_HEARTBEAT_LED_PATH);
+	if (fdt_setprop_string(blob, offs, "status", "disabled") < 0) {
+		printf("Failed to set " KERNEL_HEARTBEAT_LED_PATH "/status\n");
+	}
+}
+
 /* update device tree to support realtek specific parameters */
 #define ETHPHY0_PATH "/bus@5b000000/ethernet@5b040000"
 #define ETHPHY1_PATH "/bus@5b000000/ethernet@5b050000"
@@ -714,6 +723,11 @@ int ft_board_setup(void *blob, bd_t *bd)
 	if (env_get_yesno("enable_wifi") == 1) { // leave things alone if the variable is missing or false
 		printf("Enabling wifi regulator\n");
 		enable_wifi_regulator(blob);
+	}
+
+	if (env_get_yesno("energystar") == 1) { // leave things alone if the variable is missing or false
+		printf("Energy star mode\n");
+		disable_kernel_heartbeat(blob);
 	}
 
 	if (!env_get("ethaddr") && !env_get("eth1addr")) {

--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -165,15 +165,15 @@
 		"if ext4load mmc ${bootenvpart} " \
 			"${loadaddr} ${bootenv}; then " \
 				"env import -c ${loadaddr} ${filesize} " \
-					"display fitconfig enable_wifi " \
+					"display fitconfig enable_wifi energystar " \
 					"trybootpart bootpart bootlabel; " \
 		"elif ext4load mmc ${bootenvpart} " \
 			"${loadaddr} ${bootenv}-backup; then " \
 				"env import -c ${loadaddr} ${filesize} " \
-					"display fitconfig enable_wifi " \
+					"display fitconfig enable_wifi energystar " \
 					"bootpart bootlabel; " \
 				"env export -c ${loadaddr} " \
-					"display fitconfig enable_wifi " \
+					"display fitconfig enable_wifi energystar " \
 					"trybootpart bootpart bootlabel; " \
 				"ext4write mmc ${bootenvpart} ${loadaddr} " \
 					"/${bootenv} ${filesize}; " \
@@ -191,6 +191,9 @@
 			"ext4write mmc ${bootenvpart} ${loadaddr} " \
 				"/${bootenv} ${filesize}; " \
 			"part uuid mmc ${_trybootpart} bootuuid; " \
+			"if test ${energystar} = true; then " \
+				"setenv -f bootargs_append ${bootargs_append} energystar=1; " \
+			"fi; " \
 			"setenv bootargs reboot=h ${bootargs_secureboot} " \
 				"console=${console} " \
 				"bootenv=PARTUUID=${bootenvuuid} " \
@@ -215,6 +218,9 @@
 		"fi; " \
 		"echo Booting ${bootfile} from mmc ${_bootpart} ...; " \
 		"part uuid mmc ${_bootpart} bootuuid; " \
+		"if test ${energystar} = true; then " \
+			"setenv -f bootargs_append ${bootargs_append} energystar=1; " \
+		"fi; " \
 		"setenv bootargs reboot=h ${bootargs_secureboot} " \
 			"console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
@@ -229,6 +235,9 @@
 		"fi; " \
 		"echo Failover boot ${bootfile} from mmc ${_bootpart} ...; " \
 		"part uuid mmc ${_bootpart} bootuuid; " \
+		"if test ${energystar} = true; then " \
+			"setenv -f bootargs_append ${bootargs_append} energystar=1; " \
+		"fi; " \
 		"setenv bootargs reboot=h ${bootargs_secureboot} " \
 			"console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \


### PR DESCRIPTION
- select energystar mode via bootloader environment variable:

    # fw_setenv energystar true

- pass 'energystar=1' to kernel command line when mode selected
- disable kernel heartbeat LED device tree node when in energystar mode

Fixes: [PLAT-7438]

[PLAT-7438]: https://chargepoint.atlassian.net/browse/PLAT-7438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ