### PR TITLE
ucb: consolidate power saving measures under single variable

### DIFF
--- a/board/chargepoint/imx8dxp_ucb/imx8dxp_ucb.c
+++ b/board/chargepoint/imx8dxp_ucb/imx8dxp_ucb.c
@@ -700,14 +700,12 @@ int ft_board_setup(void *blob, bd_t *bd)
 		realtek_phy_supp(blob);
 	}
 
-	if (env_get_yesno("enable_wifi") == 1) { // leave things alone if the variable is missing or false
-		printf("Enabling wifi regulator\n");
-		enable_wifi_regulator(blob);
-	}
-
-	if (env_get_yesno("energystar") == 1) { // leave things alone if the variable is missing or false
+	if (env_get_yesno("energystar") == 1) {
 		printf("Energy star mode\n");
 		disable_kernel_heartbeat(blob);
+	} else {
+		printf("Enabling wifi regulator\n");
+		enable_wifi_regulator(blob);
 	}
 
 	if (!env_get("ethaddr") && !env_get("eth1addr")) {

--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -165,15 +165,15 @@
 		"if ext4load mmc ${bootenvpart} " \
 			"${loadaddr} ${bootenv}; then " \
 				"env import -c ${loadaddr} ${filesize} " \
-					"display fitconfig enable_wifi energystar " \
+					"display fitconfig energystar " \
 					"trybootpart bootpart bootlabel; " \
 		"elif ext4load mmc ${bootenvpart} " \
 			"${loadaddr} ${bootenv}-backup; then " \
 				"env import -c ${loadaddr} ${filesize} " \
-					"display fitconfig enable_wifi energystar " \
+					"display fitconfig energystar " \
 					"bootpart bootlabel; " \
 				"env export -c ${loadaddr} " \
-					"display fitconfig enable_wifi energystar " \
+					"display fitconfig energystar " \
 					"trybootpart bootpart bootlabel; " \
 				"ext4write mmc ${bootenvpart} ${loadaddr} " \
 					"/${bootenv} ${filesize}; " \


### PR DESCRIPTION
- remove enable_wifi variable and change wifi to default on.
- turn off wifi/bt regulator is now behind the same `energystar=true` variable as other power savings

Fixes: [PLAT-7654]

[PLAT-7654]: https://chargepoint.atlassian.net/browse/PLAT-7654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ