### PR TITLE
target/cpnk:Set bootdelay to 0.

### DIFF
--- a/include/configs/imx6cpnk.h
+++ b/include/configs/imx6cpnk.h
@@ -219,6 +219,7 @@
 	"compat_image=/boot/zImage\0" \
 	"compat_fdt_file=/boot/imx6qp-sabresd-cpnk.dtb\0" \
 	"compat_fdt_addr=0x18000000\0" \
+	"bootdelay=0\0" \
 	"bootenvpart=0:b\0" \
 	"bootenv=uboot.env\0" \
 	"bootfile=fitImage\0" \
@@ -313,6 +314,7 @@
 	"if test -z \"${ota_filename}\"; then "\
 		"setenv -f ota_filename ${compat_ota_filename}; " \
 	"fi; " \
+	"setenv -f bootdelay ${bootdelay}; " \
 	"if test ${ota_triggered} -eq 1; then " \
 		"if ext4load mmc ${compat_mmcdev}:${compat_ota_mmcpart} " \
 			"${loadaddr} ${compat_ota_engine}; then " \


### PR DESCRIPTION
Legacy emb-cpnk code set default bootdelay to 6 and in emb-uboot-imx it expects the value will be 0 and it never alters. So the boot-delay is always 6 and it cant be altered. Added support in bootloader to enforce bootdelay to 0.

Fixes: EMBSW-11449