### PR TITLE
board/cpnk: Add reset reason to bootargs.

### DIFF
--- a/board/chargepoint/common/bootreason.h
+++ b/board/chargepoint/common/bootreason.h
@@ -78,7 +78,6 @@ static inline const char *get_wdog_reset_reason(void)
 #endif
 	switch (cause) {
 	case 0x00001:
-	case 0x00011:
 		return "POR";
 	case 0x00004:
 		return "CSU";
@@ -97,6 +96,13 @@ static inline const char *get_wdog_reset_reason(void)
 		}
 #endif
 		return "WDOG";
+#endif
+        case 0x00011:
+		/* In this case both POWER  and watchdog flag is set*/	
+#ifdef  CONFIG_MX7
+                return "POR + WDOG1";
+#else
+                return "POR + WDOG";
 #endif
 	case 0x00020:
 		return "JTAG_HIGH-Z";

--- a/include/configs/imx6cpnk.h
+++ b/include/configs/imx6cpnk.h
@@ -327,7 +327,7 @@
 		"${loadaddr} ${compat_image}; then " \
 		"setenv bootargs console=${console},${baudrate} " \
 			"video=${video} " \
-			"root=/dev/mmcblk0p5 rootwait rw; " \
+			"root=/dev/mmcblk0p5 rootwait rw ${bootargs_append}; " \
 		"if ext4load mmc ${compat_mmcdev}:${compat_mmcpart} " \
 			"${compat_fdt_addr} ${compat_fdt_file}; then " \
 			"bootz ${loadaddr} - ${compat_fdt_addr}; " \


### PR DESCRIPTION
Add reset reason to the boot args so its used for debugging.

Fixes: [EMBSW-11457]

[EMBSW-11457]: https://chargepoint.atlassian.net/browse/EMBSW-11457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ