### PR TITLE
board/cpnk: Initialize GPIO pins for Last Gasp

### DIFF
--- a/board/chargepoint/imx6cpnk/imx6cpnk.c
+++ b/board/chargepoint/imx6cpnk/imx6cpnk.c
@@ -467,6 +467,12 @@ static void setup_display(void)
 }
 #endif /* CONFIG_VIDEO_IPUV3 */
 
+static iomux_v3_cfg_t const lg_init_pads[] = {
+        /* Last GASP controls */
+        IOMUX_PADS(v__GPIO1_IO13  | MUX_PAD_CTRL(NO_PAD_CTRL)), /* LG CHG_ENABLE */
+        IOMUX_PADS(PAD_SD2_DAT0__GPIO1_IO15  | MUX_PAD_CTRL(NO_PAD_CTRL)), /* LG CHG_CAPGOOD */
+        IOMUX_PADS(PAD_GPIO_2__GPIO1_IO02 | MUX_PAD_CTRL(NO_PAD_CTRL)), /* LG CHG_PFWn */
+};
 
 /* forward declare pin_mux init since pin_mux.h cannot be included */
 extern void BOARD_InitPins(void);
@@ -475,6 +481,9 @@ int board_early_init_f(void)
 {
 	/* call generated pin_mux code from the NXP pin tools */
 	BOARD_InitPins();
+
+        /* Setup Last Gasp init pads */
+        imx_iomux_v3_setup_multiple_pads(lg_init_pads, ARRAY_SIZE(lg_init_pads));
 
 #if defined(CONFIG_VIDEO_IPUV3)
 	setup_display();
@@ -816,9 +825,7 @@ static iomux_v3_cfg_t const usb_otg_pads[] = {
 };
 
 static iomux_v3_cfg_t const usb_hc1_pads[] = {
-#define GPIO_USB_PWREN  IMX_GPIO_NR(1, 4)
         IOMUX_PADS(PAD_GPIO_4__GPIO1_IO04 | MUX_PAD_CTRL(NO_PAD_CTRL)),
-#define GPIO_USB_RESET  IMX_GPIO_NR(1, 5)
         IOMUX_PADS(PAD_GPIO_5__GPIO1_IO05 | MUX_PAD_CTRL(NO_PAD_CTRL)),
 };
 int board_ehci_hcd_init(int port)


### PR DESCRIPTION
Initialize the last gasp gpio pins.

Fixes: EMBSW-11458