### PR TITLE
fix(cpnk): set the bootdelay to default

### DIFF
--- a/include/configs/imx6cpnk.h
+++ b/include/configs/imx6cpnk.h
@@ -219,7 +219,6 @@
 	"compat_image=/boot/zImage\0" \
 	"compat_fdt_file=/boot/imx6qp-sabresd-cpnk.dtb\0" \
 	"compat_fdt_addr=0x18000000\0" \
-	"bootdelay=0\0" \
 	"bootenvpart=0:b\0" \
 	"bootenv=uboot.env\0" \
 	"bootfile=fitImage\0" \
@@ -314,7 +313,6 @@
 	"if test -z \"${ota_filename}\"; then "\
 		"setenv -f ota_filename ${compat_ota_filename}; " \
 	"fi; " \
-	"setenv -f bootdelay ${bootdelay}; " \
 	"if test ${ota_triggered} -eq 1; then " \
 		"if ext4load mmc ${compat_mmcdev}:${compat_ota_mmcpart} " \
 			"${loadaddr} ${compat_ota_engine}; then " \


### PR DESCRIPTION
Factory needs a special uboot build with bootdelay set to 0 for the customer image. We are reverting
bootdelay to default.

Fixes: [PLAT-8471]

[PLAT-8471]: https://chargepoint.atlassian.net/browse/PLAT-8471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ