### PR TITLE
fix: properly persist the energystar bootloader environment variable

### DIFF
--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -186,7 +186,7 @@
 			"setenv -f _trybootpart ${trybootpart}; " \
 			"setenv -f trybootpart; " \
 			"env export -c ${loadaddr} " \
-				"display fitconfig " \
+				"display fitconfig energystar " \
 				"trybootpart bootpart bootlabel; " \
 			"ext4write mmc ${bootenvpart} ${loadaddr} " \
 				"/${bootenv} ${filesize}; " \


### PR DESCRIPTION
Add it to a missing spot in the boot scripts.

Fixes: [PLAT-8573]

[PLAT-8573]: https://chargepoint.atlassian.net/browse/PLAT-8573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ