### PR TITLE
fix: force fsck and repair via kernel command line

### DIFF
--- a/include/configs/imx8dxp_ucb.h
+++ b/include/configs/imx8dxp_ucb.h
@@ -194,7 +194,8 @@
 			"if test \"${energystar}\" = true; then " \
 				"setenv -f bootargs_append ${bootargs_append} energystar=1; " \
 			"fi; " \
-			"setenv bootargs reboot=h ${bootargs_secureboot} " \
+			"setenv bootargs fsck.mode=force fsck.repair=yes " \
+			    "reboot=h ${bootargs_secureboot} " \
 				"console=${console} " \
 				"bootenv=PARTUUID=${bootenvuuid} " \
 				"root=PARTUUID=${bootuuid} rootwait rw " \
@@ -221,7 +222,8 @@
 		"if test \"${energystar}\" = true; then " \
 			"setenv -f bootargs_append ${bootargs_append} energystar=1; " \
 		"fi; " \
-		"setenv bootargs reboot=h ${bootargs_secureboot} " \
+		"setenv bootargs fsck.mode=force fsck.repair=yes " \
+		    "reboot=h ${bootargs_secureboot} " \
 			"console=${console} " \
 			"bootenv=PARTUUID=${bootenvuuid} " \
 			"root=PARTUUID=${bootuuid} rootwait rw " \


### PR DESCRIPTION
Per systemd-fsck docs, these command line options force checks and unconditional repairs on all correctly-marked filesystems in /etc/fstab.

Fixes: [PLAT-6710]

[PLAT-6710]: https://chargepoint.atlassian.net/browse/PLAT-6710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ