### PR TITLE
feat(ucb): read board id to select audio codec

### DIFF
--- a/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
+++ b/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
@@ -123,7 +123,6 @@
 			        SC_P_QSPI0B_DATA2_LSIO_GPIO3_IO20               0xC0000041 /* ENET1_INT */
 			        SC_P_QSPI0B_DATA3_LSIO_GPIO3_IO21               0xC0000041 /* ENET1_PPS */
 
-			        SC_P_USB_SS3_TC2_LSIO_GPIO4_IO05                0xC0000041 /* USBHUB_FLEXCMD */
 			        SC_P_SPI0_CS0_LSIO_GPIO1_IO08                   0xC0000041 /* GPIO2_0 / LED */
 			        SC_P_SPI0_CS1_LSIO_GPIO1_IO07                   0xC0000041 /* GPIO2_1 / LED */
 			        SC_P_SPI0_SCK_LSIO_GPIO1_IO04                   0xC0000041 /* GPIO2_2 / ETH0_RST_B */
@@ -134,6 +133,9 @@
 			        SC_P_SPI2_SCK_LSIO_GPIO1_IO03                   0xC0000041 /* GPIO2_6 / MOD_eRST */
 			        SC_P_SPI2_SDI_LSIO_GPIO1_IO02                   0xC0000041 /* GPIO2_7 / MOD_IGT */
 			        SC_P_SPI2_SDO_LSIO_GPIO1_IO01                   0xC0000041 /* GPIO2_8 / MOD_STATUS_IO */
+
+					SC_P_USB_SS3_TC0_LSIO_GPIO4_IO03				0x20000040 /* GPIO4_3 / BD_ID_0 */
+					SC_P_USB_SS3_TC2_LSIO_GPIO4_IO05				0x20000040 /* GPIO4_5 / BD_ID_1 */
 		        >;
 	        };
 


### PR DESCRIPTION
board id of 01 means the wm8974 audio codec needs to be turned on, and a board id of 10 means the wm8940 needs to be turned on. edited the uboot device tree to configure the pinmux correctly to allow reading the board id gpios

[PLAT-10687]

[PLAT-10687]: https://chargepoint.atlassian.net/browse/PLAT-10687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ