### PR TITLE
fix(ucb): uboot fix to assign soundcard based on boardid

### DIFF
--- a/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
+++ b/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
@@ -123,7 +123,6 @@
 			        SC_P_QSPI0B_DATA2_LSIO_GPIO3_IO20               0xC0000041 /* ENET1_INT */
 			        SC_P_QSPI0B_DATA3_LSIO_GPIO3_IO21               0xC0000041 /* ENET1_PPS */
 
-			        SC_P_USB_SS3_TC2_LSIO_GPIO4_IO05                0xC0000041 /* USBHUB_FLEXCMD */
 			        SC_P_SPI0_CS0_LSIO_GPIO1_IO08                   0xC0000041 /* GPIO2_0 / LED */
 			        SC_P_SPI0_CS1_LSIO_GPIO1_IO07                   0xC0000041 /* GPIO2_1 / LED */
 			        SC_P_SPI0_SCK_LSIO_GPIO1_IO04                   0xC0000041 /* GPIO2_2 / ETH0_RST_B */
@@ -134,6 +133,8 @@
 			        SC_P_SPI2_SCK_LSIO_GPIO1_IO03                   0xC0000041 /* GPIO2_6 / MOD_eRST */
 			        SC_P_SPI2_SDI_LSIO_GPIO1_IO02                   0xC0000041 /* GPIO2_7 / MOD_IGT */
 			        SC_P_SPI2_SDO_LSIO_GPIO1_IO01                   0xC0000041 /* GPIO2_8 / MOD_STATUS_IO */
+				SC_P_USB_SS3_TC0_LSIO_GPIO4_IO03		0x20000040 /* GPIO4_3 / BD_ID_0 */
+				SC_P_USB_SS3_TC2_LSIO_GPIO4_IO05		0x20000040 /* GPIO4_5 / BD_ID_1 */
 		        >;
 	        };
 


### PR DESCRIPTION
Added fix to detect board id and assign the sound card based on the board id.

Working FDT set to 987da0e0
   Uncompressing Kernel Image
   Loading Ramdisk to fae3c000, end fc64ffaa ... OK
   Loading Device Tree to 00000000fae22000, end 00000000fae3bc5a ... OK
Working FDT set to fae22000
Phy vendor: 2
Audio Codec: wm8974
Disable clock-controller@59580000 rsrc 512 not owned Disable clock-controller@5a4d0000 rsrc 62 not owned Disable clock-controller@5ac90000 rsrc 102 not owned

Starting kernel ...

Fixes: PLAT-11696