### PR TITLE
board/chargepoint: ensure the audio codec is set in provision image

### DIFF
--- a/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
+++ b/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
@@ -63,18 +63,6 @@
 			regulator-always-on;
 		};
 	};
-
-	sound: sound {
-		compatible = "fsl,imx-audio-wm8974";
-		model = "wm8974-audio";
-		cpu-dai = <&sai0>;
-		audio-codec = <&wm8974>;
-		audio-routing =
-			"Ext Spk", "MONOOUT",
-			"Mic", "Mic Bias",
-			"MICN", "Mic";
-	};
-
 };
 
 &iomuxc {
@@ -82,206 +70,207 @@
 	pinctrl-0 = <&pinctrl_hog>;
 	iomuxc-imx8dxp-ucb {
 		pinctrl_hog: hoggrp {
-		        fsl,pins = <
-			        SC_P_SPI3_SCK_LSIO_GPIO0_IO13                   0xC0000041 /* CSI0_GPIO1 */
-			        SC_P_SPI3_SDI_LSIO_GPIO0_IO15                   0xC0000041 /* CSI0_GPIO2 */
-			        SC_P_SPI3_SDO_LSIO_GPIO0_IO14                   0xC0000041 /* CSI0_GPIO3 */
-			        SC_P_SPI3_CS0_LSIO_GPIO0_IO16                   0xC0000041 /* CSI0_GPIO4 */
-			        SC_P_MIPI_CSI0_GPIO0_00_LSIO_GPIO3_IO08         0xC0000041 /* CSI_GPIO_5 */
-			        SC_P_MIPI_CSI0_GPIO0_01_LSIO_GPIO3_IO07         0xC0000041 /* CSI_GPIO_6 */
-			        SC_P_MIPI_CSI0_MCLK_OUT_MIPI_CSI0_ACM_MCLK_OUT  0xC0000041 /* CSI_XVCLK */
+			fsl,pins = <
+				SC_P_SPI3_SCK_LSIO_GPIO0_IO13	0xC0000041 /* CSI0_GPIO1 */
+				SC_P_SPI3_SDI_LSIO_GPIO0_IO15	0xC0000041 /* CSI0_GPIO2 */
+				SC_P_SPI3_SDO_LSIO_GPIO0_IO14	0xC0000041 /* CSI0_GPIO3 */
+				SC_P_SPI3_CS0_LSIO_GPIO0_IO16	0xC0000041 /* CSI0_GPIO4 */
+				SC_P_MIPI_CSI0_GPIO0_00_LSIO_GPIO3_IO08	0xC0000041 /* CSI_GPIO_5 */
+				SC_P_MIPI_CSI0_GPIO0_01_LSIO_GPIO3_IO07	0xC0000041 /* CSI_GPIO_6 */
+				SC_P_MIPI_CSI0_MCLK_OUT_MIPI_CSI0_ACM_MCLK_OUT  0xC0000041 /* CSI_XVCLK */
 
-			        SC_P_SAI1_RXD_LSIO_GPIO0_IO29                   0xC0000041 /* SER_PWR_EN */
-			        SC_P_SAI1_RXC_LSIO_GPIO0_IO30                   0xC0000041 /* MAG_INT_B */
-			        SC_P_SAI1_RXFS_LSIO_GPIO0_IO31                  0xC0000041 /* MAG_DRDY */
-			        SC_P_MIPI_DSI0_I2C0_SCL_LSIO_GPIO1_IO25         0xC0000041 /* RTC_IRQn */
-			        SC_P_MIPI_DSI0_I2C0_SDA_LSIO_GPIO1_IO26         0xC0000041 /* ACCEL_INT_B */
-			        SC_P_MIPI_DSI1_I2C0_SCL_LSIO_GPIO1_IO29         0xC0000041 /* CHG_CAPGOOD */
-			        SC_P_MIPI_DSI1_I2C0_SDA_LSIO_GPIO1_IO30         0xC0000041 /* CHGn_PFW */
-			        SC_P_QSPI0A_DQS_LSIO_GPIO3_IO13                 0xC0000041 /* CHG_ENABLE */
-			        SC_P_QSPI0A_SS0_B_LSIO_GPIO3_IO14               0xC0000041 /* Tamper_TEST */
-			        SC_P_QSPI0A_SS1_B_LSIO_GPIO3_IO15               0xC0000041 /* Tamper_RST_N */
+				SC_P_SAI1_RXD_LSIO_GPIO0_IO29	0xC0000041 /* SER_PWR_EN */
+				SC_P_SAI1_RXC_LSIO_GPIO0_IO30	0xC0000041 /* MAG_INT_B */
+				SC_P_SAI1_RXFS_LSIO_GPIO0_IO31	0xC0000041 /* MAG_DRDY */
+				SC_P_MIPI_DSI0_I2C0_SCL_LSIO_GPIO1_IO25	0xC0000041 /* RTC_IRQn */
+				SC_P_MIPI_DSI0_I2C0_SDA_LSIO_GPIO1_IO26	0xC0000041 /* ACCEL_INT_B */
+				SC_P_MIPI_DSI1_I2C0_SCL_LSIO_GPIO1_IO29	0xC0000041 /* CHG_CAPGOOD */
+				SC_P_MIPI_DSI1_I2C0_SDA_LSIO_GPIO1_IO30	0xC0000041 /* CHGn_PFW */
+				SC_P_QSPI0A_DQS_LSIO_GPIO3_IO13	0xC0000041 /* CHG_ENABLE */
+				SC_P_QSPI0A_SS0_B_LSIO_GPIO3_IO14	0xC0000041 /* Tamper_TEST */
+				SC_P_QSPI0A_SS1_B_LSIO_GPIO3_IO15	0xC0000041 /* Tamper_RST_N */
 
-			        SC_P_CSI_EN_LSIO_GPIO3_IO02                     0xC0000041 /* UX_5V_OC */
-			        SC_P_CSI_RESET_LSIO_GPIO3_IO03                  0xC0000041 /* UX_GSTIC_RSTn */
-			        SC_P_CSI_MCLK_LSIO_GPIO3_IO01                   0xC0000041 /* UX_PWR_EN */
-			        SC_P_CSI_PCLK_LSIO_GPIO3_IO00                   0xC0000041 /* UX_GSTIC_TS */
-			        SC_P_MCLK_IN0_LSIO_GPIO0_IO19                   0xC0000041 /* RFID_PWR_EN */
+				SC_P_CSI_EN_LSIO_GPIO3_IO02	0xC0000041 /* UX_5V_OC */
+				SC_P_CSI_RESET_LSIO_GPIO3_IO03	0xC0000041 /* UX_GSTIC_RSTn */
+				SC_P_CSI_MCLK_LSIO_GPIO3_IO01	0xC0000041 /* UX_PWR_EN */
+				SC_P_CSI_PCLK_LSIO_GPIO3_IO00	0xC0000041 /* UX_GSTIC_TS */
+				SC_P_MCLK_IN0_LSIO_GPIO0_IO19	0xC0000041 /* RFID_PWR_EN */
 
-			        SC_P_MIPI_DSI0_GPIO0_00_MIPI_DSI0_PWM0_OUT      0x00000020 /* LCD_PWM */
-			        SC_P_MIPI_DSI0_GPIO0_01_LSIO_GPIO1_IO28         0xC0000041 /* LCD_SEL_10H_8L */
-			        SC_P_QSPI0A_DATA0_LSIO_GPIO3_IO09               0xC0000041 /* LCD_REV_SCAN */
-			        SC_P_QSPI0A_DATA1_LSIO_GPIO3_IO10               0xC0000041 /* LCD_3V3_EN */
-			        SC_P_QSPI0A_DATA2_LSIO_GPIO3_IO11               0xC0000041 /* LCD_BLU_EN */
-			        SC_P_QSPI0A_DATA3_LSIO_GPIO3_IO12               0xC0000041 /* SPK_PWREN */
+				SC_P_MIPI_DSI0_GPIO0_00_MIPI_DSI0_PWM0_OUT	0x00000020 /* LCD_PWM */
+				SC_P_MIPI_DSI0_GPIO0_01_LSIO_GPIO1_IO28	0xC0000041 /* LCD_SEL_10H_8L */
+				SC_P_QSPI0A_DATA0_LSIO_GPIO3_IO09	0xC0000041 /* LCD_REV_SCAN */
+				SC_P_QSPI0A_DATA1_LSIO_GPIO3_IO10	0xC0000041 /* LCD_3V3_EN */
+				SC_P_QSPI0A_DATA2_LSIO_GPIO3_IO11	0xC0000041 /* LCD_BLU_EN */
+				SC_P_QSPI0A_DATA3_LSIO_GPIO3_IO12	0xC0000041 /* SPK_PWREN */
 
-			        SC_P_QSPI0B_SS0_B_LSIO_GPIO3_IO23               0xC0000041 /* WIFI_WAKE_B */
-			        SC_P_QSPI0B_SS1_B_LSIO_GPIO3_IO24               0xC0000041 /* WIFI_PCIE_W_DISABLEn */
-			        SC_P_QSPI0B_SCLK_LSIO_GPIO3_IO17                0xC0000041 /* WIFI_EN */
-			        SC_P_QSPI0B_DATA0_LSIO_GPIO3_IO18               0xC0000041 /* ENET0_INT */
-			        SC_P_QSPI0B_DATA1_LSIO_GPIO3_IO19               0xC0000041 /* ENET0_PPS */
-			        SC_P_QSPI0B_DATA2_LSIO_GPIO3_IO20               0xC0000041 /* ENET1_INT */
-			        SC_P_QSPI0B_DATA3_LSIO_GPIO3_IO21               0xC0000041 /* ENET1_PPS */
+				SC_P_QSPI0B_SS0_B_LSIO_GPIO3_IO23	0xC0000041 /* WIFI_WAKE_B */
+				SC_P_QSPI0B_SS1_B_LSIO_GPIO3_IO24	0xC0000041 /* WIFI_PCIE_W_DISABLEn */
+				SC_P_QSPI0B_SCLK_LSIO_GPIO3_IO17	0xC0000041 /* WIFI_EN */
+				SC_P_QSPI0B_DATA0_LSIO_GPIO3_IO18	0xC0000041 /* ENET0_INT */
+				SC_P_QSPI0B_DATA1_LSIO_GPIO3_IO19	0xC0000041 /* ENET0_PPS */
+				SC_P_QSPI0B_DATA2_LSIO_GPIO3_IO20	0xC0000041 /* ENET1_INT */
+				SC_P_QSPI0B_DATA3_LSIO_GPIO3_IO21	0xC0000041 /* ENET1_PPS */
 
-			        SC_P_SPI0_CS0_LSIO_GPIO1_IO08                   0xC0000041 /* GPIO2_0 / LED */
-			        SC_P_SPI0_CS1_LSIO_GPIO1_IO07                   0xC0000041 /* GPIO2_1 / LED */
-			        SC_P_SPI0_SCK_LSIO_GPIO1_IO04                   0xC0000041 /* GPIO2_2 / ETH0_RST_B */
-			        SC_P_SPI0_SDI_LSIO_GPIO1_IO05                   0xC0000041 /* GPIO2_3 / ETH1_RST_B */
-			        SC_P_SPI0_SDO_LSIO_GPIO1_IO06                   0xC0000041 /* GPIO2_4 / USB_RST_N */
+				SC_P_SPI0_CS0_LSIO_GPIO1_IO08	0xC0000041 /* GPIO2_0 / LED */
+				SC_P_SPI0_CS1_LSIO_GPIO1_IO07	0xC0000041 /* GPIO2_1 / LED */
+				SC_P_SPI0_SCK_LSIO_GPIO1_IO04	0xC0000041 /* GPIO2_2 / ETH0_RST_B */
+				SC_P_SPI0_SDI_LSIO_GPIO1_IO05	0xC0000041 /* GPIO2_3 / ETH1_RST_B */
+				SC_P_SPI0_SDO_LSIO_GPIO1_IO06	0xC0000041 /* GPIO2_4 / USB_RST_N */
 
-			        SC_P_SPI2_CS0_LSIO_GPIO1_IO00                   0xC0000041 /* GPIO2_5 / MOD_ENBL */
-			        SC_P_SPI2_SCK_LSIO_GPIO1_IO03                   0xC0000041 /* GPIO2_6 / MOD_eRST */
-			        SC_P_SPI2_SDI_LSIO_GPIO1_IO02                   0xC0000041 /* GPIO2_7 / MOD_IGT */
-			        SC_P_SPI2_SDO_LSIO_GPIO1_IO01                   0xC0000041 /* GPIO2_8 / MOD_STATUS_IO */
-				SC_P_USB_SS3_TC0_LSIO_GPIO4_IO03		0x20000040 /* GPIO4_3 / BD_ID_0 */
-				SC_P_USB_SS3_TC2_LSIO_GPIO4_IO05		0x20000040 /* GPIO4_5 / BD_ID_1 */
-		        >;
-	        };
+				SC_P_SPI2_CS0_LSIO_GPIO1_IO00	0xC0000041 /* GPIO2_5 / MOD_ENBL */
+				SC_P_SPI2_SCK_LSIO_GPIO1_IO03	0xC0000041 /* GPIO2_6 / MOD_eRST */
+				SC_P_SPI2_SDI_LSIO_GPIO1_IO02	0xC0000041 /* GPIO2_7 / MOD_IGT */
+				SC_P_SPI2_SDO_LSIO_GPIO1_IO01	0xC0000041 /* GPIO2_8 / MOD_STATUS_IO */
+				SC_P_USB_SS3_TC0_LSIO_GPIO4_IO03	0x20000040 /* GPIO4_3 / BD_ID_0 */
+				SC_P_USB_SS3_TC2_LSIO_GPIO4_IO05	0x20000040 /* GPIO4_5 / BD_ID_1 */
+			>;
+		};
 
-	        pinctrl_pcieb: pcieagrp {
-		        fsl,pins = <
-			        SC_P_PCIE_CTRL0_PERST_B_LSIO_GPIO4_IO00         0x06000021
-			        SC_P_PCIE_CTRL0_CLKREQ_B_LSIO_GPIO4_IO01        0x06000021
-			        SC_P_PCIE_CTRL0_WAKE_B_LSIO_GPIO4_IO02          0x04000021
-		        >;
-	        };
+		pinctrl_pcieb: pcieagrp {
+			fsl,pins = <
+				SC_P_PCIE_CTRL0_PERST_B_LSIO_GPIO4_IO00	 0x06000021
+				SC_P_PCIE_CTRL0_CLKREQ_B_LSIO_GPIO4_IO01	0x06000021
+				SC_P_PCIE_CTRL0_WAKE_B_LSIO_GPIO4_IO02	  0x04000021
+			>;
+		};
 
-	        pinctrl_usdhc1: usdhc1grp {
-		        fsl,pins = <
-			        SC_P_EMMC0_CLK_CONN_EMMC0_CLK                   0x06000041
-			        SC_P_EMMC0_CMD_CONN_EMMC0_CMD                   0x00000021
-			        SC_P_EMMC0_DATA0_CONN_EMMC0_DATA0               0x00000021
-			        SC_P_EMMC0_DATA1_CONN_EMMC0_DATA1               0x00000021
-			        SC_P_EMMC0_DATA2_CONN_EMMC0_DATA2               0x00000021
-			        SC_P_EMMC0_DATA3_CONN_EMMC0_DATA3               0x00000021
-			        SC_P_EMMC0_DATA4_CONN_EMMC0_DATA4               0x00000021
-			        SC_P_EMMC0_DATA5_CONN_EMMC0_DATA5               0x00000021
-			        SC_P_EMMC0_DATA6_CONN_EMMC0_DATA6               0x00000021
-			        SC_P_EMMC0_DATA7_CONN_EMMC0_DATA7               0x00000021
-			        SC_P_EMMC0_STROBE_CONN_EMMC0_STROBE             0x00000041
-			        /*SC_P_EMMC0_RESET_B_LSIO_GPIO4_IO18              0xC0000041*/  /*Reset not connected in UCB*/
-		        >;
-	        };
+		pinctrl_usdhc1: usdhc1grp {
+			fsl,pins = <
+				SC_P_EMMC0_CLK_CONN_EMMC0_CLK		   0x06000041
+				SC_P_EMMC0_CMD_CONN_EMMC0_CMD		   0x00000021
+				SC_P_EMMC0_DATA0_CONN_EMMC0_DATA0	       0x00000021
+				SC_P_EMMC0_DATA1_CONN_EMMC0_DATA1	       0x00000021
+				SC_P_EMMC0_DATA2_CONN_EMMC0_DATA2	       0x00000021
+				SC_P_EMMC0_DATA3_CONN_EMMC0_DATA3	       0x00000021
+				SC_P_EMMC0_DATA4_CONN_EMMC0_DATA4	       0x00000021
+				SC_P_EMMC0_DATA5_CONN_EMMC0_DATA5	       0x00000021
+				SC_P_EMMC0_DATA6_CONN_EMMC0_DATA6	       0x00000021
+				SC_P_EMMC0_DATA7_CONN_EMMC0_DATA7	       0x00000021
+				SC_P_EMMC0_STROBE_CONN_EMMC0_STROBE	     0x00000041
+				/* Reset not connected in UCB */
+				/*SC_P_EMMC0_RESET_B_LSIO_GPIO4_IO18	      0x00000041*/
+			>;
+		};
 
-	        pinctrl_lpuart0: lpuart0grp {
-		        fsl,pins = <
-			        SC_P_UART0_RX_ADMA_UART0_RX                     0x06000020
-			        SC_P_UART0_TX_ADMA_UART0_TX                     0x06000020
-		        >;
-	        };
+		pinctrl_lpuart0: lpuart0grp {
+			fsl,pins = <
+				SC_P_UART0_RX_ADMA_UART0_RX		     0x06000020
+				SC_P_UART0_TX_ADMA_UART0_TX		     0x06000020
+			>;
+		};
 
-	        pinctrl_lpuart1: lpuart1grp {
-		        fsl,pins = <
-			        SC_P_UART1_TX_ADMA_UART1_TX                     0x06000020
-			        SC_P_UART1_RX_ADMA_UART1_RX                     0x06000020
-			        SC_P_UART1_RTS_B_ADMA_UART1_RTS_B               0x06000020
-			        SC_P_UART1_CTS_B_ADMA_UART1_CTS_B               0x06000020
-		        >;
-	        };
+		pinctrl_lpuart1: lpuart1grp {
+			fsl,pins = <
+				SC_P_UART1_TX_ADMA_UART1_TX		     0x06000020
+				SC_P_UART1_RX_ADMA_UART1_RX		     0x06000020
+				SC_P_UART1_RTS_B_ADMA_UART1_RTS_B	       0x06000020
+				SC_P_UART1_CTS_B_ADMA_UART1_CTS_B	       0x06000020
+			>;
+		};
 
-	        pinctrl_lpuart2: lpuart2grp {
-		        fsl,pins = <
-			        SC_P_UART2_TX_ADMA_UART2_TX                     0x06000020
-			        SC_P_UART2_RX_ADMA_UART2_RX                     0x06000020
-		        >;
-	        };
+		pinctrl_lpuart2: lpuart2grp {
+			fsl,pins = <
+				SC_P_UART2_TX_ADMA_UART2_TX		     0x06000020
+				SC_P_UART2_RX_ADMA_UART2_RX		     0x06000020
+			>;
+		};
 
-	        pinctrl_fec1: fec1grp {
-		        fsl,pins = <
-			        SC_P_COMP_CTL_GPIO_1V8_3V3_ENET_ENETB0_PAD          0x000014a0
-			        SC_P_COMP_CTL_GPIO_1V8_3V3_ENET_ENETB1_PAD          0x000014a0
-			        SC_P_ENET0_MDC_CONN_ENET0_MDC                       0x06000020
-			        SC_P_ENET0_MDIO_CONN_ENET0_MDIO                     0x06000020
-			        SC_P_ENET0_RGMII_TX_CTL_CONN_ENET0_RGMII_TX_CTL     0x00000061
-			        SC_P_ENET0_RGMII_TXC_CONN_ENET0_RGMII_TXC           0x00000061
-			        SC_P_ENET0_RGMII_TXD0_CONN_ENET0_RGMII_TXD0         0x00000061
-			        SC_P_ENET0_RGMII_TXD1_CONN_ENET0_RGMII_TXD1         0x00000061
-			        SC_P_ENET0_RGMII_TXD2_CONN_ENET0_RGMII_TXD2         0x00000061
-			        SC_P_ENET0_RGMII_TXD3_CONN_ENET0_RGMII_TXD3         0x00000061
-			        SC_P_ENET0_RGMII_RXC_CONN_ENET0_RGMII_RXC           0x00000061
-			        SC_P_ENET0_RGMII_RX_CTL_CONN_ENET0_RGMII_RX_CTL     0x00000061
-			        SC_P_ENET0_RGMII_RXD0_CONN_ENET0_RGMII_RXD0         0x00000061
-			        SC_P_ENET0_RGMII_RXD1_CONN_ENET0_RGMII_RXD1         0x00000061
-			        SC_P_ENET0_RGMII_RXD2_CONN_ENET0_RGMII_RXD2         0x00000061
-			        SC_P_ENET0_RGMII_RXD3_CONN_ENET0_RGMII_RXD3         0x00000061
-		        >;
-	        };
+		pinctrl_fec1: fec1grp {
+			fsl,pins = <
+				SC_P_COMP_CTL_GPIO_1V8_3V3_ENET_ENETB0_PAD	  0x000014a0
+				SC_P_COMP_CTL_GPIO_1V8_3V3_ENET_ENETB1_PAD	  0x000014a0
+				SC_P_ENET0_MDC_CONN_ENET0_MDC		       0x06000020
+				SC_P_ENET0_MDIO_CONN_ENET0_MDIO		     0x06000020
+				SC_P_ENET0_RGMII_TX_CTL_CONN_ENET0_RGMII_TX_CTL     0x00000061
+				SC_P_ENET0_RGMII_TXC_CONN_ENET0_RGMII_TXC	   0x00000061
+				SC_P_ENET0_RGMII_TXD0_CONN_ENET0_RGMII_TXD0	 0x00000061
+				SC_P_ENET0_RGMII_TXD1_CONN_ENET0_RGMII_TXD1	 0x00000061
+				SC_P_ENET0_RGMII_TXD2_CONN_ENET0_RGMII_TXD2	 0x00000061
+				SC_P_ENET0_RGMII_TXD3_CONN_ENET0_RGMII_TXD3	 0x00000061
+				SC_P_ENET0_RGMII_RXC_CONN_ENET0_RGMII_RXC	   0x00000061
+				SC_P_ENET0_RGMII_RX_CTL_CONN_ENET0_RGMII_RX_CTL     0x00000061
+				SC_P_ENET0_RGMII_RXD0_CONN_ENET0_RGMII_RXD0	 0x00000061
+				SC_P_ENET0_RGMII_RXD1_CONN_ENET0_RGMII_RXD1	 0x00000061
+				SC_P_ENET0_RGMII_RXD2_CONN_ENET0_RGMII_RXD2	 0x00000061
+				SC_P_ENET0_RGMII_RXD3_CONN_ENET0_RGMII_RXD3	 0x00000061
+			>;
+		};
 
-	        pinctrl_fec2: fec2grp {
-		        fsl,pins = <
-			        SC_P_ESAI0_SCKR_CONN_ENET1_RGMII_TX_CTL             0x00000060
-			        SC_P_ESAI0_FSR_CONN_ENET1_RGMII_TXC                 0x00000060
-			        SC_P_ESAI0_TX4_RX1_CONN_ENET1_RGMII_TXD0            0x00000060
-			        SC_P_ESAI0_TX5_RX0_CONN_ENET1_RGMII_TXD1            0x00000060
-			        SC_P_ESAI0_FST_CONN_ENET1_RGMII_TXD2                0x00000060
-			        SC_P_ESAI0_SCKT_CONN_ENET1_RGMII_TXD3               0x00000060
-			        SC_P_ESAI0_TX0_CONN_ENET1_RGMII_RXC                 0x00000060
-			        SC_P_SPDIF0_TX_CONN_ENET1_RGMII_RX_CTL              0x00000060
-			        SC_P_SPDIF0_RX_CONN_ENET1_RGMII_RXD0                0x00000060
-			        SC_P_ESAI0_TX3_RX2_CONN_ENET1_RGMII_RXD1            0x00000060
-			        SC_P_ESAI0_TX2_RX3_CONN_ENET1_RGMII_RXD2            0x00000060
-			        SC_P_ESAI0_TX1_CONN_ENET1_RGMII_RXD3                0x00000060
-                        >;
-                };
+		pinctrl_fec2: fec2grp {
+			fsl,pins = <
+				SC_P_ESAI0_SCKR_CONN_ENET1_RGMII_TX_CTL	     0x00000060
+				SC_P_ESAI0_FSR_CONN_ENET1_RGMII_TXC		 0x00000060
+				SC_P_ESAI0_TX4_RX1_CONN_ENET1_RGMII_TXD0	    0x00000060
+				SC_P_ESAI0_TX5_RX0_CONN_ENET1_RGMII_TXD1	    0x00000060
+				SC_P_ESAI0_FST_CONN_ENET1_RGMII_TXD2		0x00000060
+				SC_P_ESAI0_SCKT_CONN_ENET1_RGMII_TXD3	       0x00000060
+				SC_P_ESAI0_TX0_CONN_ENET1_RGMII_RXC		 0x00000060
+				SC_P_SPDIF0_TX_CONN_ENET1_RGMII_RX_CTL	      0x00000060
+				SC_P_SPDIF0_RX_CONN_ENET1_RGMII_RXD0		0x00000060
+				SC_P_ESAI0_TX3_RX2_CONN_ENET1_RGMII_RXD1	    0x00000060
+				SC_P_ESAI0_TX2_RX3_CONN_ENET1_RGMII_RXD2	    0x00000060
+				SC_P_ESAI0_TX1_CONN_ENET1_RGMII_RXD3		0x00000060
+			>;
+		};
 
-	        pinctrl_flexcan1: flexcan0grp {
-		        fsl,pins = <
-			        SC_P_FLEXCAN0_TX_ADMA_FLEXCAN0_TX                   0x21
-			        SC_P_FLEXCAN0_RX_ADMA_FLEXCAN0_RX                   0x21
-                        >;
-	        };
+		pinctrl_flexcan1: flexcan0grp {
+			fsl,pins = <
+				SC_P_FLEXCAN0_TX_ADMA_FLEXCAN0_TX		   0x21
+				SC_P_FLEXCAN0_RX_ADMA_FLEXCAN0_RX		   0x21
+			>;
+		};
 
-	        pinctrl_flexcan2: flexcan1grp {
-		        fsl,pins = <
-			        SC_P_FLEXCAN1_TX_ADMA_FLEXCAN1_TX                   0x21
-			        SC_P_FLEXCAN1_RX_ADMA_FLEXCAN1_RX                   0x21
-                        >;
-	        };
+		pinctrl_flexcan2: flexcan1grp {
+			fsl,pins = <
+				SC_P_FLEXCAN1_TX_ADMA_FLEXCAN1_TX		   0x21
+				SC_P_FLEXCAN1_RX_ADMA_FLEXCAN1_RX		   0x21
+			>;
+		};
 
-                pinctrl_csi0_lpi2c0: csi0lpi2c0grp {
-                        fsl,pins = <
-                                SC_P_MIPI_CSI0_I2C0_SCL_MIPI_CSI0_I2C0_SCL          0xc2000020
-                                SC_P_MIPI_CSI0_I2C0_SDA_MIPI_CSI0_I2C0_SDA          0xc2000020
-                        >;
-                };
+		pinctrl_csi0_lpi2c0: csi0lpi2c0grp {
+			fsl,pins = <
+				SC_P_MIPI_CSI0_I2C0_SCL_MIPI_CSI0_I2C0_SCL	  0xc2000020
+				SC_P_MIPI_CSI0_I2C0_SDA_MIPI_CSI0_I2C0_SDA	  0xc2000020
+			>;
+		};
 
-                pinctrl_lpi2c1: lpi1cgrp {
-		        fsl,pins = <
-			        SC_P_USB_SS3_TC1_ADMA_I2C1_SCL                      0x06000021
-			        SC_P_USB_SS3_TC3_ADMA_I2C1_SDA                      0x06000021
-		        >;
-	        };
+		pinctrl_lpi2c1: lpi1cgrp {
+			fsl,pins = <
+				SC_P_USB_SS3_TC1_ADMA_I2C1_SCL		      0x06000021
+				SC_P_USB_SS3_TC3_ADMA_I2C1_SDA		      0x06000021
+			>;
+		};
 
-                pinctrl_lpi2c2: lpi2cgrp {
-		        fsl,pins = <
-			        SC_P_MIPI_DSI1_GPIO0_00_ADMA_I2C2_SCL               0x06000021
-			        SC_P_MIPI_DSI1_GPIO0_01_ADMA_I2C2_SDA               0x06000021
-		        >;
-	        };
+		pinctrl_lpi2c2: lpi2cgrp {
+			fsl,pins = <
+				SC_P_MIPI_DSI1_GPIO0_00_ADMA_I2C2_SCL	       0x06000021
+				SC_P_MIPI_DSI1_GPIO0_01_ADMA_I2C2_SDA	       0x06000021
+			>;
+		};
 
-                pinctrl_lpi2c3: lpi3cgrp {
-		        fsl,pins = <
-			        SC_P_SPI3_CS1_ADMA_I2C3_SCL                         0x06000021
-			        SC_P_MCLK_IN1_ADMA_I2C3_SDA                         0x06000021
-		        >;
-	        };
+		pinctrl_lpi2c3: lpi3cgrp {
+			fsl,pins = <
+				SC_P_SPI3_CS1_ADMA_I2C3_SCL			 0x06000021
+				SC_P_MCLK_IN1_ADMA_I2C3_SDA			 0x06000021
+			>;
+		};
 
-			pinctrl_sai0: sai0grp {
-				fsl,pins = <
-			        SC_P_SAI0_RXD_ADMA_SAI0_RXD                         0x06000040
-			        SC_P_SAI0_TXC_ADMA_SAI0_TXC                         0x06000040
-			        SC_P_SAI0_TXFS_ADMA_SAI0_TXFS                       0x06000040
-			        SC_P_SAI0_TXD_ADMA_SAI0_TXD                         0x06000060
-			        SC_P_MCLK_OUT0_ADMA_ACM_MCLK_OUT0                   0x0600004c
-		        >;
-	        };
+		pinctrl_sai0: sai0grp {
+			fsl,pins = <
+				SC_P_SAI0_RXD_ADMA_SAI0_RXD			 0x06000040
+				SC_P_SAI0_TXC_ADMA_SAI0_TXC			 0x06000040
+				SC_P_SAI0_TXFS_ADMA_SAI0_TXFS		       0x06000040
+				SC_P_SAI0_TXD_ADMA_SAI0_TXD			 0x06000060
+				SC_P_MCLK_OUT0_ADMA_ACM_MCLK_OUT0		   0x0600004c
+			>;
+		};
 
-			pinctrl_adc0: adc0grp {
-				fsl,pins = <
-					SC_P_ADC_IN0_ADMA_ADC_IN0		0x60
-				>;
-			};
-        };
+		pinctrl_adc0: adc0grp {
+			fsl,pins = <
+				SC_P_ADC_IN0_ADMA_ADC_IN0		0x60
+			>;
+		};
+	};
 };
 
 &acm {
@@ -552,6 +541,10 @@
 			data-lanes = <1 2 3 4>;
 		};
 	};
+};
+
+&gpio0_mipi_csi0 {
+	status = "disabled";
 };
 
 /* One isi_x for 4 VCx of MIPI CSI0 respectively */


### PR DESCRIPTION
There is a kernel panic if the wrong audio codec is selected on boards so ensure that the gpio mapping and boardid is queried for the kernel boot.