### PR TITLE
fix: allow any signature verification to work in development

### DIFF
--- a/board/chargepoint/common/chargepoint-pubkey.dtsi
+++ b/board/chargepoint/common/chargepoint-pubkey.dtsi
@@ -22,6 +22,7 @@
  */
 / {
 	signature {
+		required-mode = "any";
 		key-fit-dev {
 			required = "dev:conf";
 			algo = "sha256,rsa4096";


### PR DESCRIPTION
Development boot loaders should boot production signed units so any signature that is valid should be supported - but, since the production signature is only signed with one required key then and development can verify any of them.

Fixes: [PLAT-6007]

[PLAT-6007]: https://chargepoint.atlassian.net/browse/PLAT-6007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ