### PR TITLE
fix: allow any signature verification to work in development

### DIFF
--- a/board/chargepoint/common/chargepoint-pubkey.dtsi
+++ b/board/chargepoint/common/chargepoint-pubkey.dtsi
@@ -22,6 +22,7 @@
  */
 / {
 	signature {
+		required-mode = "any";
 		key-fit-dev {
 			required = "dev:conf";
 			algo = "sha256,rsa4096";

--- a/board/chargepoint/common/fitimage_keys.h
+++ b/board/chargepoint/common/fitimage_keys.h
@@ -25,7 +25,9 @@ static inline void setup_fitimage_keys(void)
 	int noffset;
 	int sig_node;
 	void *sig_blob;
-	const char *sig_prefix;
+	int allowdev;
+	const char sig_prefix[] = SIGNATURE_PREFIX;
+	const char sig_devel[] = "dev:";
 
 	/*
 	 * This will change the "u-boot" fdt required keys that
@@ -44,13 +46,13 @@ static inline void setup_fitimage_keys(void)
 
 		err = sc_seco_chip_info(ipcHndl, &lc, NULL, NULL, NULL);
 		if ((err == SC_ERR_NONE) && (lc == 0x80)) {
-			sig_prefix = SIGNATURE_PREFIX;
+			allowdev = 0;
 		} else {
-			sig_prefix = "dev:";
+			allowdev = 1;
 		}
 	} while(0);
 #else
-	sig_prefix = imx_hab_is_enabled() ? SIGNATURE_PREFIX : "dev:";
+	allowdev = imx_hab_is_enabled() ? 0 : 1;
 #endif
 	sig_blob = (void *)(uintptr_t)gd->fdt_blob;
 
@@ -67,21 +69,37 @@ static inline void setup_fitimage_keys(void)
 		int ret;
 
 		required = fdt_getprop(sig_blob, noffset, "required", NULL);
-		if ((required == NULL) ||
-		    (strncmp(required, sig_prefix, strlen(sig_prefix)) != 0))
+		if (required == NULL) {
 			continue;
-
-		/*
-		 * Copy string suffix to stack buffer before calling
-		 * ftd_setprop_string().  Otherwise the string may be truncated while
-		 * being set.
-		 */
-		memset(buf, 0, sizeof(buf));
-		strncpy(buf, &required[strlen(sig_prefix)], sizeof(buf));
-		ret = fdt_setprop_string(sig_blob, noffset, "required", buf);
-		if (ret) {
-			printf("Failed to update required signature '%s'\n",
-			       fit_get_name(sig_blob, noffset, NULL));
+		}
+		if (strncmp(required, sig_prefix, strlen(sig_prefix)) == 0) {
+			/*
+			 * Copy string suffix to stack buffer before calling
+			 * ftd_setprop_string().  Otherwise the string may be
+			 * truncated while being set.
+			 */
+			memset(buf, 0, sizeof(buf));
+			strncpy(buf, &required[strlen(sig_prefix)],
+				sizeof(buf));
+			ret = fdt_setprop_string(sig_blob, noffset,
+						 "required", buf);
+			if (ret) {
+				printf("Failed to update signature '%s'\n",
+				       fit_get_name(sig_blob, noffset, NULL));
+			}
+		}
+		if ((allowdev == 1) &&
+		    (strncmp(required, sig_devel, strlen(sig_devel)) == 0)) {
+			/* same copy reason as above */
+			memset(buf, 0, sizeof(buf));
+			strncpy(buf, &required[strlen(sig_devel)],
+				sizeof(buf));
+			ret = fdt_setprop_string(sig_blob, noffset,
+						  "required", buf);
+			if (ret) {
+				printf("Failed to update signature '%s'\n",
+				       fit_get_name(sig_blob, noffset, NULL));
+			}
 		}
 	}
 #endif

--- a/common/image-sig.c
+++ b/common/image-sig.c
@@ -435,8 +435,13 @@ error:
 int fit_config_verify_required_sigs(const void *fit, int conf_noffset,
 		const void *sig_blob)
 {
+	const char *name = fit_get_name(fit, conf_noffset, NULL);
 	int noffset;
 	int sig_node;
+	int verified = 0;
+	int reqd_sigs = 0;
+	bool reqd_policy_all = true;
+	const char *reqd_mode;
 
 	/* Work out what we need to verify */
 	sig_node = fdt_subnode_offset(sig_blob, 0, FIT_SIG_NODENAME);
@@ -446,20 +451,50 @@ int fit_config_verify_required_sigs(const void *fit, int conf_noffset,
 		return 0;
 	}
 
+	/* Get required-mode policy property from DTB */
+	reqd_mode = fdt_getprop(sig_blob, sig_node, "required-mode", NULL);
+	if (reqd_mode && !strcmp(reqd_mode, "any"))
+		reqd_policy_all = false;
+
+	debug("%s: required-mode policy set to '%s'\n", __func__,
+	      reqd_policy_all ? "all" : "any");
+
+	/*
+	 * The algorithm here is a little convoluted due to how we want it to
+	 * work. Here we work through each of the signature nodes in the
+	 * public-key area. These are in the U-Boot control devicetree. Each
+	 * node was created by signing a configuration, so we check if it is
+	 * 'required' and if so, request that it be verified.
+	 */
 	fdt_for_each_subnode(noffset, sig_blob, sig_node) {
 		const char *required;
 		int ret;
 
-		required = fdt_getprop(sig_blob, noffset, "required", NULL);
+		required = fdt_getprop(sig_blob, noffset, "required",
+				       NULL);
 		if (!required || strcmp(required, "conf"))
 			continue;
+
+		reqd_sigs++;
+
 		ret = fit_config_verify_sig(fit, conf_noffset, sig_blob,
 					    noffset);
 		if (ret) {
-			printf("Failed to verify required signature '%s'\n",
-			       fit_get_name(sig_blob, noffset, NULL));
-			return ret;
+			if (reqd_policy_all) {
+				printf("Failed to verify required signature '%s'\n",
+				       fit_get_name(sig_blob, noffset, NULL));
+				return ret;
+			}
+		} else {
+			verified++;
+			if (!reqd_policy_all)
+				break;
 		}
+	}
+
+	if (reqd_sigs && !verified) {
+		printf("Failed to verify 'any' of the required signature(s)\n");
+		return -EPERM;
 	}
 
 	return 0;


### PR DESCRIPTION
Development boot loaders should boot production signed units so any signature that is valid should be supported - but, since the production signature is only signed with one required key then and development can verify any of them.

Backported from 74ac5a6bbd70000ddd47c7777d7c2f79cea8de88

Fixes: [PLAT-6007]

[PLAT-6007]: https://chargepoint.atlassian.net/browse/PLAT-6007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ