### PR TITLE
fix(ucb): added phy-reset items to devicetree.

### DIFF
--- a/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
+++ b/board/chargepoint/imx8dxp_ucb/imx8dxp-chargepoint-ucb.dts
@@ -328,7 +328,10 @@
 	pinctrl-0 = <&pinctrl_fec1>;
 	phy-mode = "rgmii-txid";
 	phy-handle = <&ethphy0>;
-	/* TODO: phy-reset? */
+	phy-reset-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+	phy-reset-active-high = <1>;
+	phy-reset-duration = <10>;
+	phy-reset-post-delay = <200>;
 	fsl,magic-packet;
 	fsl,rgmii_rxc_dly;
 	status = "okay";
@@ -359,7 +362,10 @@
 	pinctrl-0 = <&pinctrl_fec2>;
 	phy-mode = "rgmii-txid";
 	phy-handle = <&ethphy1>;
-	/* TODO: phy-reset? */
+	phy-reset-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+	phy-reset-active-high = <1>;
+	phy-reset-duration = <10>;
+	phy-reset-post-delay = <200>;
 	fsl,magic-packet;
 	fsl,rgmii_rxc_dly;
 	status = "okay";


### PR DESCRIPTION
With 2023 uboot release board specific phy reset is done through devicetree config instead of legacy
board_eth_int(). This fixes the inconstency in bringin up ethernet phy.

Refer: doc/develop/driver-model/ethernet.rst

Fixes: PLAT-11900